### PR TITLE
Adding domain module lightning

### DIFF
--- a/libraries/domain/Lightning/Lightning/Info.plist
+++ b/libraries/domain/Lightning/Lightning/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/libraries/domain/Lightning/Lightning/LightningUseCase.swift
+++ b/libraries/domain/Lightning/Lightning/LightningUseCase.swift
@@ -1,0 +1,38 @@
+import Foundation
+import LightningInterface
+import NetworkClientInterface
+
+final class LightningUseCase {
+    
+    private let networkClient: NetworkClient
+    private let baseURL = URL(string: "https://mempool.space/api/v1/lightning/nodes/rankings/connectivity")
+    
+    init(networkClient: NetworkClient) {
+        self.networkClient = networkClient
+    }
+    
+    static func successfullyValidation(_ data: Data, response: HTTPURLResponse) -> NodesResult {
+        guard response.statusCode == 200, let nodes = try? JSONDecoder().decode([Nodes].self, from: data) else {
+            return  .failure(.invalidData)
+        }
+        return .success(nodes)
+    }
+}
+
+extension LightningUseCase: LightningInterface {
+    func fetchNodes(completion: @escaping (NodesResult) -> Void) {
+        guard let url = baseURL else {
+            completion(.failure(.invalidURL))
+            return
+        }
+        
+        networkClient.request(from: url) { result in
+            switch result {
+            case let .success((data, response)): 
+                completion(LightningUseCase.successfullyValidation(data, response: response))
+            case .failure: 
+                completion(.failure(.connectivity))
+            }
+        }
+    }
+}

--- a/libraries/domain/Lightning/Lightning/LightningUseCase.swift
+++ b/libraries/domain/Lightning/Lightning/LightningUseCase.swift
@@ -12,7 +12,9 @@ final class LightningUseCase {
     }
     
     static func successfullyValidation(_ data: Data, response: HTTPURLResponse) -> NodesResult {
-        guard response.statusCode == 200, let nodes = try? JSONDecoder().decode([Nodes].self, from: data) else {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        guard response.statusCode == 200, let nodes = try? decoder.decode([Nodes].self, from: data) else {
             return  .failure(.invalidData)
         }
         return .success(nodes)

--- a/libraries/domain/Lightning/LightningInterface/Info.plist
+++ b/libraries/domain/Lightning/LightningInterface/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/libraries/domain/Lightning/LightningInterface/LightningInterface.swift
+++ b/libraries/domain/Lightning/LightningInterface/LightningInterface.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public enum NodesError: Error {
+    case invalidURL
+    case connectivity
+    case invalidData
+}
+
+/**
+Sample: {
+ "publicKey": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+ "alias": "ACINQ",
+ "channels": 2908,
+ "capacity": 36010516297,
+ "firstSeen": 1522941222,
+ "updatedAt": 1661274935,
+ "city": { // or null
+    "de": "Vancouver",
+    "en": "Vancouver",
+    "es": "Vancouver",
+    "fr": "Vancouver",
+    "ja": "バンクーバー市",
+    "pt-BR": "Vancôver",
+    "ru": "Ванкувер"
+ }
+ "country": {
+    "de": "Vereinigte Staaten",
+    "en": "United States",
+    "es": "Estados Unidos",
+    "fr": "États Unis",
+    "ja": "アメリカ",
+    "pt-BR": "EUA",
+    "ru": "США",
+    "zh-CN": "美国"
+ }
+}
+**/
+
+public struct Nodes: Equatable, Codable {
+    public let publicKey: String
+    public let alias: String
+    public let channels: Int
+    public let capacity: Int
+    public let firstSeen: Int
+    public let updatedAt: Int
+    
+    public init(
+        publicKey: String,
+        alias: String,
+        channels: Int,
+        capacity: Int,
+        firstSeen: Int,
+        updatedAt: Int
+    ) {
+        self.publicKey = publicKey
+        self.alias = alias
+        self.channels = channels
+        self.capacity = capacity
+        self.firstSeen = firstSeen
+        self.updatedAt = updatedAt
+    }
+    
+    public static func == (lhs: Nodes, rhs: Nodes) -> Bool {
+        return lhs.publicKey == rhs.publicKey
+    }
+}
+
+public protocol LightningInterface {
+    typealias NodesResult = Result<[Nodes], NodesError>
+    func fetchNodes(completion: @escaping (NodesResult) -> Void)
+}

--- a/libraries/domain/Lightning/LightningInterface/LightningInterface.swift
+++ b/libraries/domain/Lightning/LightningInterface/LightningInterface.swift
@@ -43,6 +43,8 @@ public struct Nodes: Equatable, Codable {
     public let capacity: Int
     public let firstSeen: Int
     public let updatedAt: Int
+    public let city: [String: String]?
+    public let country: [String: String]
     
     public init(
         publicKey: String,
@@ -50,7 +52,9 @@ public struct Nodes: Equatable, Codable {
         channels: Int,
         capacity: Int,
         firstSeen: Int,
-        updatedAt: Int
+        updatedAt: Int,
+        city: [String: String]? = nil,
+        country: [String: String]
     ) {
         self.publicKey = publicKey
         self.alias = alias
@@ -58,6 +62,8 @@ public struct Nodes: Equatable, Codable {
         self.capacity = capacity
         self.firstSeen = firstSeen
         self.updatedAt = updatedAt
+        self.city = city
+        self.country = country
     }
     
     public static func == (lhs: Nodes, rhs: Nodes) -> Bool {

--- a/libraries/domain/Lightning/LightningInterface/LightningInterface.swift
+++ b/libraries/domain/Lightning/LightningInterface/LightningInterface.swift
@@ -40,9 +40,9 @@ public struct Nodes: Equatable, Codable {
     public let publicKey: String
     public let alias: String
     public let channels: Int
-    public let capacity: Int
-    public let firstSeen: Int
-    public let updatedAt: Int
+    public let capacity: Int64
+    public let firstSeen: Date
+    public let updatedAt: Date
     public let city: [String: String]?
     public let country: [String: String]
     
@@ -50,9 +50,9 @@ public struct Nodes: Equatable, Codable {
         publicKey: String,
         alias: String,
         channels: Int,
-        capacity: Int,
-        firstSeen: Int,
-        updatedAt: Int,
+        capacity: Int64,
+        firstSeen: Date,
+        updatedAt: Date,
         city: [String: String]? = nil,
         country: [String: String]
     ) {

--- a/libraries/domain/Lightning/LightningTests/Info.plist
+++ b/libraries/domain/Lightning/LightningTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/libraries/domain/Lightning/LightningTests/LightningTests.swift
+++ b/libraries/domain/Lightning/LightningTests/LightningTests.swift
@@ -96,7 +96,8 @@ private extension LightningUseCaseTests {
             channels: 2908,
             capacity: 36010516297,
             firstSeen: 1522941222,
-            updatedAt: 1661274935
+            updatedAt: 1661274935,
+            country: ["pt-BR": "EUA"]
         )
     }
     
@@ -108,7 +109,8 @@ private extension LightningUseCaseTests {
             "channels": node.channels,
             "capacity": node.capacity,
             "firstSeen": node.firstSeen,
-            "updatedAt": node.updatedAt
+            "updatedAt": node.updatedAt,
+            "country": node.country
         ]
         
         return (node, json)

--- a/libraries/domain/Lightning/LightningTests/LightningTests.swift
+++ b/libraries/domain/Lightning/LightningTests/LightningTests.swift
@@ -95,8 +95,8 @@ private extension LightningUseCaseTests {
             alias: "alias",
             channels: 2908,
             capacity: 36010516297,
-            firstSeen: 1522941222,
-            updatedAt: 1661274935,
+            firstSeen: Date(timeIntervalSince1970: 1720033718),
+            updatedAt: Date(timeIntervalSince1970: 1720033718),
             country: ["pt-BR": "EUA"]
         )
     }
@@ -108,8 +108,8 @@ private extension LightningUseCaseTests {
             "alias": node.alias,
             "channels": node.channels,
             "capacity": node.capacity,
-            "firstSeen": node.firstSeen,
-            "updatedAt": node.updatedAt,
+            "firstSeen": node.firstSeen.timeIntervalSince1970,
+            "updatedAt": node.updatedAt.timeIntervalSince1970,
             "country": node.country
         ]
         

--- a/libraries/domain/Lightning/LightningTests/LightningTests.swift
+++ b/libraries/domain/Lightning/LightningTests/LightningTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import NetworkClientInterface
+import LightningInterface
+@testable import Lightning
+
+final class LightningUseCaseTests: XCTestCase {
+    
+    let copyURL = URL(string: "https://mempool.space/api/v1/lightning/nodes/rankings/connectivity")!
+    
+    func test_validate_urlRequest() {
+        let (sut, client) = makeSUT()
+        
+        sut.fetchNodes { _ in }
+        
+        XCTAssertEqual(client.urlRequests, [copyURL])
+    }
+    
+    func test_fechNodes_and_returned_error_for_lost_connectivity() {
+        let (sut, client) = makeSUT()
+        
+        assert(sut, completion: .failure(.connectivity) , when: {
+            let error = NSError(domain: "any error", code: 0)
+            client.completionWith(result: .failure(error))
+        })
+    }
+    
+    func test_fechNodes_and_returned_error_for_invalid_data() {
+        let (sut, client) = makeSUT()
+        
+        assert(sut, completion: .failure(.invalidData), when: {
+            client.completionWith(statusCode: 400)
+        })
+    }
+    
+    func test_fechNodes_and_returned_empty_list() {
+        let (sut, client) = makeSUT()
+        
+        assert(sut, completion: .success([]), when: {
+            let data = makeJson([])
+            client.completionWith(statusCode: 200, data: data)
+        })
+    }
+    
+    func test_fechNodes_and_returned_invalid_data_with_empty_list() {
+        let (sut, client) = makeSUT()
+        
+        assert(sut, completion: .failure(.invalidData)) {
+            let data = makeJson([])
+            client.completionWith(statusCode: 400, data: data)
+        }
+    }
+    
+    func test_fechNodes_and_returned_nodes() {
+        let (sut, client) = makeSUT()
+        let item1 = makeNodeAndJson()
+        
+        assert(sut, completion: .success([item1.model])) {
+            let data = makeJson([item1.json])
+            client.completionWith(statusCode: 200, data: data)
+        }
+    }
+}
+
+private extension LightningUseCaseTests {
+    func makeSUT() -> (sut: LightningUseCase, networkSpy: NetworkClientSpy)  {
+        let network = NetworkClientSpy()
+        let sut = LightningUseCase(networkClient: network)
+        return (sut, network)
+    }
+    
+    private func assert(
+        _ sut: LightningUseCase,
+        completion result: LightningInterface.NodesResult,
+        when action: () -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        
+        var expectedResult = [LightningInterface.NodesResult]()
+        sut.fetchNodes { expectedResult.append($0) }
+        
+        action()
+        
+        XCTAssertEqual(expectedResult, [result], file: file, line: line)
+    }
+    
+    func makeJson(_ items: [[String: Any]]) -> Data {
+        let data = try! JSONSerialization.data(withJSONObject: items)
+        return data
+    }
+    
+    func makeNodes() -> Nodes {
+        Nodes(
+            publicKey: "publicKey",
+            alias: "alias",
+            channels: 2908,
+            capacity: 36010516297,
+            firstSeen: 1522941222,
+            updatedAt: 1661274935
+        )
+    }
+    
+    func makeNodeAndJson() -> (model: Nodes, json: [String: Any] ) {
+        let node = makeNodes()
+        let json: [String : Any] = [
+            "publicKey": node.publicKey,
+            "alias": node.alias,
+            "channels": node.channels,
+            "capacity": node.capacity,
+            "firstSeen": node.firstSeen,
+            "updatedAt": node.updatedAt
+        ]
+        
+        return (node, json)
+    }
+}

--- a/libraries/domain/Lightning/LightningTests/NetworkClientSpy.swift
+++ b/libraries/domain/Lightning/LightningTests/NetworkClientSpy.swift
@@ -1,0 +1,23 @@
+import Foundation
+import NetworkClientInterface
+
+final class NetworkClientSpy: NetworkClient {
+    
+    private(set) var urlRequests = [URL]()
+    private var completionHandler: ((NetworkClientResult) -> Void)?
+    
+    func request(from url: URL, completion: @escaping (NetworkClientResult) -> Void) {
+        urlRequests.append(url)
+        completionHandler = completion
+    }
+    
+    func completionWith(result: NetworkClientResult) {
+        completionHandler?(result)
+    }
+    
+    func completionWith(statusCode: Int, data: Data = Data()) {
+        let response = HTTPURLResponse(url: urlRequests[0], statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        completionHandler?(.success((data, response)))
+    }
+    
+}

--- a/libraries/domain/Lightning/project.yml
+++ b/libraries/domain/Lightning/project.yml
@@ -1,0 +1,54 @@
+############
+# Targets
+############
+
+targets:
+
+  LightningInterface:
+    
+    # templates
+    templates:
+      - StaticFramework
+    
+    # templateAttributes
+    templateAttributes:
+      frameworkPath: libraries/domain/Lightning
+    
+  Lightning:
+    
+    # templates
+    templates:
+      - StaticFramework
+    
+    # templateAttributes
+    templateAttributes:
+      frameworkPath: libraries/domain/Lightning
+    
+    dependencies:
+     - target: DependencyInjector
+     - target: NetworkClient
+     - target: LightningInterface
+      
+    # scheme
+    scheme:
+      gatherCoverageData: true
+      coverageTargets:
+        - Lightning
+      testTargets:
+        - name: LightningTests
+          parallelizable: true
+          randomExecutionOrder: true
+
+  LightningTests:
+    
+    # templates
+    templates:
+      - FrameworkTests
+    
+    # templateAttributes
+    templateAttributes:
+      frameworkPath: libraries/domain/Lightning
+
+    # dependencies
+    dependencies:
+      - target: Lightning

--- a/project.yml
+++ b/project.yml
@@ -9,3 +9,5 @@ include:
   relativePaths: false
 - path: libraries/core/NetworkClient/project.yml
   relativePaths: false
+- path: libraries/domain/Lightning/project.yml
+  relativePaths: false


### PR DESCRIPTION
Adding Lightning Module, responsible for the business rule.

- **NodesError**: Error handling
- **Nodes**: Data structure
- **LightningInterface** Interface for downloading nodes

```Swift
public enum NodesError: Error {
    case invalidURL
    case connectivity
    case invalidData
}

public struct Nodes: Equatable, Codable {
    public let publicKey: String
    public let alias: String
    public let channels: Int
    public let capacity: Int64
    public let firstSeen: Date
    public let updatedAt: Date
    public let city: [String: String]?
    public let country: [String: String]
    
    public init(
        publicKey: String,
        alias: String,
        channels: Int,
        capacity: Int64,
        firstSeen: Date,
        updatedAt: Date,
        city: [String: String]? = nil,
        country: [String: String]
    ) {
        self.publicKey = publicKey
        self.alias = alias
        self.channels = channels
        self.capacity = capacity
        self.firstSeen = firstSeen
        self.updatedAt = updatedAt
        self.city = city
        self.country = country
    }
    
    public static func == (lhs: Nodes, rhs: Nodes) -> Bool {
        return lhs.publicKey == rhs.publicKey
    }
}

public protocol LightningInterface {
    typealias NodesResult = Result<[Nodes], NodesError>
    func fetchNodes(completion: @escaping (NodesResult) -> Void)
}

```

```swift
final class LightningUseCase {
    
    private let networkClient: NetworkClient
    private let baseURL = URL(string: "https://mempool.space/api/v1/lightning/nodes/rankings/connectivity")
    
    init(networkClient: NetworkClient) {
        self.networkClient = networkClient
    }
    
    static func successfullyValidation(_ data: Data, response: HTTPURLResponse) -> NodesResult {
        let decoder = JSONDecoder()
        decoder.dateDecodingStrategy = .secondsSince1970
        guard response.statusCode == 200, let nodes = try? decoder.decode([Nodes].self, from: data) else {
            return  .failure(.invalidData)
        }
        return .success(nodes)
    }
}

extension LightningUseCase: LightningInterface {
    func fetchNodes(completion: @escaping (NodesResult) -> Void) {
        guard let url = baseURL else {
            completion(.failure(.invalidURL))
            return
        }
        
        networkClient.request(from: url) { result in
            switch result {
            case let .success((data, response)): 
                completion(LightningUseCase.successfullyValidation(data, response: response))
            case .failure: 
                completion(.failure(.connectivity))
            }
        }
    }
}

```